### PR TITLE
Critical bug fix to getAllMeta() + new method

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ $book->hasMeta('someKey');
 
 $book->updateMeta('someKey', 'anotherValue');
 
+$book->addOrUpdateMeta('someKey', 'someValue');
+
 $book->deleteMeta('someKey');
 
 $book->getAllMeta();

--- a/src/Metable.php
+++ b/src/Metable.php
@@ -78,7 +78,7 @@ trait Metable
     }
 
     /**
-     * Add meta, or update if it already exists.
+     * Add or update meta if it already exists.
      * @param  string $key
      * @param  mixed $value
      * @return object|bool

--- a/src/Metable.php
+++ b/src/Metable.php
@@ -11,7 +11,7 @@ trait Metable
      */
     public function getAllMeta()
     {
-        return collect($this->meta->pluck('value', 'key'));
+        return collect($this->meta()->pluck('value', 'key'));
     }
 
     /**

--- a/src/Metable.php
+++ b/src/Metable.php
@@ -78,6 +78,17 @@ trait Metable
     }
 
     /**
+     * Add meta, or update if it already exists.
+     * @param  string $key
+     * @param  mixed $value
+     * @return object|bool
+     */
+    public function addOrUpdateMeta($key, $value)
+    {
+        return $this->hasMeta($key) ? $this->updateMeta($key, $value) : $this->addMeta($key, $value);
+    }
+
+    /**
      * Delete meta.
      *
      * @param  string $key


### PR DESCRIPTION
There was a critical bug with the getAllMeta() method. It was referencing ``->meta->`` instead of ``->meta()->``. This pull request fixes it as well as makes it uniform with the other method's references of the ``meta()`` method. **This was an issue that was breaking the ``getAllMeta()`` method completely.**

Additionally, I added a helpful method ``addOrUpdateMeta()``. Instead of forcing the developer to write an if/else statement to determine which method to use, they can shorthand with the ``addOrUpdateMeta()`` method. Under the hood it simply uses a ternary operator with ``hasMeta()``, ``updateMeta()`` and ``addMeta()``.

Lastly, I updated the readme to reflect the new method.