### PR TITLE
addMeta() only if key does not exist

### DIFF
--- a/src/Metable.php
+++ b/src/Metable.php
@@ -62,10 +62,12 @@ trait Metable
      */
     public function addMeta($key, $value)
     {
-        return $this->meta()->create([
-            'key'   => $key,
-            'value' => $value,
-        ]);
+        if ($this->meta()->where('key', $key)->count()) {
+            return $this->meta()->create([
+                'key'   => $key,
+                'value' => $value,
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
addMeta() adds infinite metas even where the key is already set.
`$model->addMeta('someKey', 'true'); $model->addMeta('someKey', 'false');` adds 2 metas with same key and different values. 
This should not be possible because `getMeta()` returns the FIRST item, so all subsequent keys are useless.

This update returns `null` when trying to add the same key (even with different value) on the same Model ID (metable_id)