### PR TITLE
Removed $table

### DIFF
--- a/src/Meta.php
+++ b/src/Meta.php
@@ -6,12 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 
 class Meta extends Model
 {
-    /**
-     * The database table used by the model.
-     *
-     * @var string
-     */
-    protected $table = 'meta';
 
     /**
      * Casts.


### PR DESCRIPTION
Per Laravel naming conventions all tables should be plurals, so `protected $table = 'meta';` is not needed as Laravel defaults to the `metas` table.