### PR TITLE
Meta table to plural

### DIFF
--- a/database/migrations/2017_05_04_100000_create_meta_table.php
+++ b/database/migrations/2017_05_04_100000_create_meta_table.php
@@ -13,7 +13,7 @@ class CreateMetaTable extends Migration
      */
     public function up()
     {
-        Schema::create('meta', function (Blueprint $table) {
+        Schema::create('metas', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('metable_id')->unsigned();
             $table->string('metable_type');
@@ -32,6 +32,6 @@ class CreateMetaTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('meta');
+        Schema::dropIfExists('metas');
     }
 }


### PR DESCRIPTION
Per Laravel naming conventions all tables should be plurals, this automates the `protected $table = 'meta';`and can be removed.