### PR TITLE
Missing "not" operator

### DIFF
--- a/src/Metable.php
+++ b/src/Metable.php
@@ -62,7 +62,7 @@ trait Metable
      */
     public function addMeta($key, $value)
     {
-        if ($this->meta()->where('key', $key)->count()) {
+        if (!$this->meta()->where('key', $key)->count()) {
             return $this->meta()->create([
                 'key'   => $key,
                 'value' => $value,


### PR DESCRIPTION
Last commit had a missing "Not" operator (!) on line 65. Now the meta is created if count() <= 0