### PR TITLE
getMetaValue: improved to a single query

### DIFF
--- a/src/Metable.php
+++ b/src/Metable.php
@@ -51,7 +51,11 @@ trait Metable
      */
     public function getMetaValue($key)
     {
-        return $this->hasMeta($key) ? $this->getMeta($key)->value : null;
+        if ($meta = $this->getMeta($key)) {
+            return $meta->value;
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
`getMetaValue` improved to a single query. 
Before this it would do one query to check for the meta, and then a new query to get the meta value.